### PR TITLE
클라이언트 공개 정보 API 확인 필요

### DIFF
--- a/src/client/dto/res.dto.ts
+++ b/src/client/dto/res.dto.ts
@@ -68,16 +68,19 @@ export class ClientResDto implements Client {
 
 export class ClientPublicResDto implements Client {
   @ApiProperty({
-    description: 'name of the client',
+    description: 'The UUID of the client',
+    example: 'd290f1ee-6c54-4b01-90e6-d701748f0851',
+  })
+  @Expose()
+  get clientId(): string {
+    return this.uuid;
+  }
+
+  @ApiProperty({
+    description: 'The name of the client',
     example: 'groups',
   })
   name: string;
-
-  @ApiProperty({
-    description: 'uuid of the client',
-    example: 'd290f1ee-6c54-4b01-90e6-d701748f0851',
-  })
-  uuid: string;
 
   @ApiProperty({
     description: 'The date the client was created',
@@ -86,16 +89,19 @@ export class ClientPublicResDto implements Client {
   createdAt: Date;
 
   @ApiProperty({
-    description: "the scope which need to use the client's service",
+    description: "The scope which need to use the client's service",
     example: ['profile', 'email'],
   })
   scopes: string[];
 
   @ApiProperty({
-    description: "the scope whether need or not in the client's service",
+    description: "The scope whether need or not in the client's service",
     example: ['student_id'],
   })
   optionalScopes: string[];
+
+  @Exclude()
+  uuid: string;
 
   @Exclude()
   secret: string;

--- a/src/client/dto/res.dto.ts
+++ b/src/client/dto/res.dto.ts
@@ -66,6 +66,54 @@ export class ClientResDto implements Client {
   }
 }
 
+export class ClientPublicResDto implements Client {
+  @ApiProperty({
+    description: 'name of the client',
+    example: 'groups',
+  })
+  name: string;
+
+  @ApiProperty({
+    description: 'uuid of the client',
+    example: 'd290f1ee-6c54-4b01-90e6-d701748f0851',
+  })
+  uuid: string;
+
+  @ApiProperty({
+    description: 'The date the client was created',
+    example: '2021-07-01T00:00:00.000Z',
+  })
+  createdAt: Date;
+
+  @ApiProperty({
+    description: "the scope which need to use the client's service",
+    example: ['profile', 'email'],
+  })
+  scopes: string[];
+
+  @ApiProperty({
+    description: "the scope whether need or not in the client's service",
+    example: ['student_id'],
+  })
+  optionalScopes: string[];
+
+  @Exclude()
+  secret: string;
+
+  @Exclude()
+  urls: string[];
+
+  @Exclude()
+  updatedAt: Date;
+
+  @Exclude()
+  idTokenAllowed: boolean;
+
+  constructor(client: Client) {
+    Object.assign(this, client);
+  }
+}
+
 export class ClientCredentialResDto implements Client {
   @ApiProperty({
     description: 'Client id',


### PR DESCRIPTION
Fixes #77

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 클라이언트의 공개 정보를 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다.
  - 제공되는 정보는 이름, 고유 식별자, 생성일, 권한 등의 기본 데이터로 구성되며 민감한 정보는 제외됩니다.

- **문서**
  - API 문서가 업데이트되어 응답 형식 및 에러 상황에 대한 설명이 보완되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->