### PR TITLE
fix: refresh token with same site none

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -51,7 +51,7 @@ export class AuthController {
     response.cookie('refreshToken', refreshToken, {
       httpOnly: true,
       secure: true,
-      sameSite: 'strict',
+      sameSite: 'none',
       expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 30 * 6),
       path: '/auth',
     });
@@ -70,7 +70,7 @@ export class AuthController {
     response.clearCookie('refreshToken', {
       httpOnly: true,
       secure: true,
-      sameSite: 'strict',
+      sameSite: 'none',
       path: '/auth',
     });
   }
@@ -93,7 +93,7 @@ export class AuthController {
     response.cookie('refreshToken', newRefreshToken, {
       httpOnly: true,
       secure: true,
-      sameSite: 'strict',
+      sameSite: 'none',
       expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 30 * 6),
       path: '/auth',
     });


### PR DESCRIPTION
same site가 strict 로 되어있으면, 프론트에서 쿠키를 사용할 수 없어서 refresh가 불가능합니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
    - 인증 관련 쿠키의 `sameSite` 속성이 `'strict'`에서 `'none'`으로 변경되어, 다양한 환경에서 로그인, 로그아웃, 토큰 갱신 시 쿠키 동작이 더 일관되고 호환성 있게 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->