### PR TITLE
Use nonce in id token

### DIFF
--- a/prisma/dbml/schema.dbml
+++ b/prisma/dbml/schema.dbml
@@ -42,6 +42,7 @@ Table refresh_token {
   token String [pk]
   createdAt DateTime [default: `now()`, not null]
   expiresAt DateTime [not null]
+  nonce String
   scopes String[] [not null]
   clientUuid String [not null]
   userUuid String [not null]

--- a/prisma/migrations/20250501051404_add_nonce/migration.sql
+++ b/prisma/migrations/20250501051404_add_nonce/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "refresh_token" ADD COLUMN     "nonce" VARCHAR(255);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -58,6 +58,7 @@ model RefreshToken {
   token     String   @id
   createdAt DateTime @default(now())
   expiresAt DateTime
+  nonce     String?  @db.VarChar(255)
   scopes    String[]
 
   clientUuid String @db.Uuid

--- a/src/oauth/dto/req.dto.ts
+++ b/src/oauth/dto/req.dto.ts
@@ -1,6 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Expose, Transform } from 'class-transformer';
-import { IsArray, IsIn, IsOptional, IsString } from 'class-validator';
+import {
+  IsArray,
+  IsIn,
+  IsOptional,
+  IsString,
+  MaxLength,
+} from 'class-validator';
 import { ClientScopeList } from 'src/client/types/clientScopes.type';
 
 import { OauthAuthorizeException } from '../exceptions/oauth.authorize.exception';
@@ -126,6 +132,7 @@ export class AuthorizationReqDto {
     description: 'nonce of the client',
   })
   @IsString()
+  @MaxLength(255)
   @IsOptional()
   nonce?: string;
 }

--- a/src/oauth/oauth.repository.ts
+++ b/src/oauth/oauth.repository.ts
@@ -46,6 +46,7 @@ export class OauthRepository {
     scopes: string[],
     userUuid: string,
     clientUuid: string,
+    nonce?: string,
   ): Promise<RefreshToken> {
     return this.prismaService.refreshToken.create({
       data: {
@@ -53,6 +54,7 @@ export class OauthRepository {
         userUuid,
         clientUuid,
         scopes,
+        nonce,
         expiresAt: new Date(Date.now() + MAX_REFRESH_TOKEN_AGE * 1000),
       },
     });

--- a/src/oauth/oauth.service.ts
+++ b/src/oauth/oauth.service.ts
@@ -151,6 +151,7 @@ export class OauthService {
         codeChallengeMethod,
         redirectUri,
         scope,
+        nonce,
       },
       {
         prefix: this.CodePrefix,

--- a/src/oauth/types/authorizeCache.type.ts
+++ b/src/oauth/types/authorizeCache.type.ts
@@ -8,4 +8,5 @@ export type AuthorizeCacheType = {
   codeChallenge: string;
   redirectUri: string;
   scope: ScopeType[];
+  nonce?: string;
 };


### PR DESCRIPTION
Fixes #88

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - OpenID Connect 인증 플로우에서 ID 토큰에 `nonce` 값이 포함됩니다.
  - 인증 요청 시 `nonce` 파라미터를 지원하며, 최대 255자까지 입력할 수 있습니다.

- **버그 수정**
  - OpenID Connect 인증 시 `nonce`가 누락된 경우 적절한 오류 메시지가 반환됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->