### PR TITLE
fix: inject camel case field in basic auth guard

### DIFF
--- a/src/oauth/guards/basicAuth.guard.ts
+++ b/src/oauth/guards/basicAuth.guard.ts
@@ -16,6 +16,8 @@ export class BasicAuthGuard implements CanActivate {
         const [username, password] = basicAuthContent.split(':');
         request.body = {
           ...(request.body || {}),
+          client_id: username,
+          client_secret: password,
           clientId: username,
           clientSecret: password,
         };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 인증 요청 시 `client_id` 및 `client_secret` 값이 추가로 지원되어, 일부 OAuth 클라이언트와의 호환성이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->