### PR TITLE
fix: use serialization of token res dto

### DIFF
--- a/src/oauth/dto/res.dto.ts
+++ b/src/oauth/dto/res.dto.ts
@@ -70,6 +70,10 @@ export class TokenResDto {
     enum: ScopeList,
   })
   scope: ScopeType[];
+
+  constructor(partial: Partial<TokenResDto>) {
+    Object.assign(this, partial);
+  }
 }
 
 export class UserInfoResDto {

--- a/src/oauth/dto/res.dto.ts
+++ b/src/oauth/dto/res.dto.ts
@@ -11,6 +11,7 @@ export class TokenResDto {
   })
   @Expose({
     name: 'access_token',
+    toPlainOnly: true,
   })
   accessToken: string;
 
@@ -21,6 +22,7 @@ export class TokenResDto {
   })
   @Expose({
     name: 'token_type',
+    toPlainOnly: true,
   })
   tokenType: string;
 
@@ -31,6 +33,7 @@ export class TokenResDto {
   })
   @Expose({
     name: 'expires_in',
+    toPlainOnly: true,
   })
   expiresIn: number;
 
@@ -41,6 +44,7 @@ export class TokenResDto {
   })
   @Expose({
     name: 'refresh_token',
+    toPlainOnly: true,
   })
   refreshToken?: string;
 
@@ -51,6 +55,7 @@ export class TokenResDto {
   })
   @Expose({
     name: 'refresh_token_expires_in',
+    toPlainOnly: true,
   })
   refreshTokenExpiresIn?: number;
 
@@ -61,6 +66,7 @@ export class TokenResDto {
   })
   @Expose({
     name: 'id_token',
+    toPlainOnly: true,
   })
   idToken?: string;
 
@@ -70,10 +76,6 @@ export class TokenResDto {
     enum: ScopeList,
   })
   scope: ScopeType[];
-
-  constructor(partial: Partial<TokenResDto>) {
-    Object.assign(this, partial);
-  }
 }
 
 export class UserInfoResDto {

--- a/src/oauth/oauth.controller.ts
+++ b/src/oauth/oauth.controller.ts
@@ -10,7 +10,6 @@ import {
   Post,
   Query,
   Redirect,
-  SerializeOptions,
   UseGuards,
   UseInterceptors,
   UsePipes,
@@ -106,10 +105,12 @@ export class OauthController {
   @ApiConsumes('application/x-www-form-urlencoded', 'application/json')
   @ApiBadRequestResponse({ description: 'invalid request' })
   @UseGuards(BasicAuthGuard)
-  @SerializeOptions({ type: TokenResDto })
   @Post('token')
-  token(@Body() body: TokenReqDto): Promise<TokenResDto> {
-    return this.oauthService.token(body as GrantContentType);
+  async token(@Body() body: TokenReqDto): Promise<TokenResDto> {
+    const res = await this.oauthService.token(body as GrantContentType);
+    const tokenResDto = new TokenResDto();
+    Object.assign(tokenResDto, res);
+    return tokenResDto;
   }
 
   @ApiOperation({

--- a/src/oauth/oauth.controller.ts
+++ b/src/oauth/oauth.controller.ts
@@ -10,6 +10,7 @@ import {
   Post,
   Query,
   Redirect,
+  SerializeOptions,
   UseGuards,
   UseInterceptors,
   UsePipes,
@@ -105,6 +106,7 @@ export class OauthController {
   @ApiConsumes('application/x-www-form-urlencoded', 'application/json')
   @ApiBadRequestResponse({ description: 'invalid request' })
   @UseGuards(BasicAuthGuard)
+  @SerializeOptions({ type: TokenResDto })
   @Post('token')
   token(@Body() body: TokenReqDto): Promise<TokenResDto> {
     return this.oauthService.token(body as GrantContentType);

--- a/src/oauth/oauth.controller.ts
+++ b/src/oauth/oauth.controller.ts
@@ -108,9 +108,7 @@ export class OauthController {
   @Post('token')
   async token(@Body() body: TokenReqDto): Promise<TokenResDto> {
     const res = await this.oauthService.token(body as GrantContentType);
-    const tokenResDto = new TokenResDto();
-    Object.assign(tokenResDto, res);
-    return tokenResDto;
+    return new TokenResDto(res);
   }
 
   @ApiOperation({

--- a/src/oauth/oauth.controller.ts
+++ b/src/oauth/oauth.controller.ts
@@ -106,9 +106,8 @@ export class OauthController {
   @ApiBadRequestResponse({ description: 'invalid request' })
   @UseGuards(BasicAuthGuard)
   @Post('token')
-  async token(@Body() body: TokenReqDto): Promise<TokenResDto> {
-    const res = await this.oauthService.token(body as GrantContentType);
-    return new TokenResDto(res);
+  token(@Body() body: TokenReqDto): Promise<TokenResDto> {
+    return this.oauthService.token(body as GrantContentType);
   }
 
   @ApiOperation({


### PR DESCRIPTION
```ts
const accessToken = 'accessToken';
const refreshToken = 'refreshToken';
const idToken = 'idToken';
const scope = 'scope';
const cache = {
  scope,
};
const res = {
  accessToken,
  tokenType: 'Bearer',
  expiresIn: 3 * 60 * 60, // 3 hours
  refreshToken,
  refreshTokenExpiresIn: 3 * 30 * 24 * 60 * 60, // 3 months
  idToken,
  scope: cache.scope,
};
console.log(plainToInstance(TokenResDto, res));
console.log(instanceToPlain(plainToInstance(TokenResDto, res)));
```

```
TokenResDto {
  accessToken: 'accessToken',
  tokenType: 'Bearer',
  expiresIn: 10800,
  refreshToken: 'refreshToken',
  refreshTokenExpiresIn: 7776000,
  idToken: 'idToken',
  scope: 'scope'
}
{
  access_token: 'accessToken',
  token_type: 'Bearer',
  expires_in: 10800,
  refresh_token: 'refreshToken',
  refresh_token_expires_in: 7776000,
  id_token: 'idToken',
  scope: 'scope'
}
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **개선 사항**
  - 토큰 발급 엔드포인트의 응답 형식이 더욱 일관되게 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->