### PR TITLE
이메일 대소문자 무시하고 찾기

### DIFF
--- a/src/user/dto/req.dto.ts
+++ b/src/user/dto/req.dto.ts
@@ -1,13 +1,9 @@
 import { IsGistEmail } from '@lib/global';
 import { IsStudentId } from '@lib/global/validator/studentId.validator';
+import { BadRequestException } from '@nestjs/common';
 import { ApiProperty } from '@nestjs/swagger';
-import {
-  IsEmail,
-  IsJWT,
-  IsLowercase,
-  IsString,
-  MaxLength,
-} from 'class-validator';
+import { Transform } from 'class-transformer';
+import { IsEmail, IsJWT, IsString, MaxLength } from 'class-validator';
 
 export class ChangePasswordDto {
   @ApiProperty({
@@ -41,7 +37,12 @@ export class RegisterDto {
   })
   @IsEmail()
   @IsGistEmail({ message: 'GIST 이메일을 입력해주세요.' })
-  @IsLowercase()
+  @Transform(({ value }) => {
+    if (typeof value === 'string') {
+      return value.toLowerCase();
+    }
+    throw new BadRequestException('이메일 형식이 올바르지 않습니다.');
+  })
   email: string;
 
   @ApiProperty({

--- a/src/user/dto/req.dto.ts
+++ b/src/user/dto/req.dto.ts
@@ -1,7 +1,13 @@
 import { IsGistEmail } from '@lib/global';
 import { IsStudentId } from '@lib/global/validator/studentId.validator';
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEmail, IsJWT, IsString, MaxLength } from 'class-validator';
+import {
+  IsEmail,
+  IsJWT,
+  IsLowercase,
+  IsString,
+  MaxLength,
+} from 'class-validator';
 
 export class ChangePasswordDto {
   @ApiProperty({
@@ -35,6 +41,7 @@ export class RegisterDto {
   })
   @IsEmail()
   @IsGistEmail({ message: 'GIST 이메일을 입력해주세요.' })
+  @IsLowercase()
   email: string;
 
   @ApiProperty({


### PR DESCRIPTION
Fixes #81

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 회원가입 시 이메일 입력값이 소문자로 자동 변환되도록 개선되었습니다.
  - 이메일 형식이 올바르지 않을 경우 오류 메시지가 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->