### PR TITLE
fix: transform scope format

### DIFF
--- a/src/oauth/dto/res.dto.ts
+++ b/src/oauth/dto/res.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { Expose } from 'class-transformer';
+import { Expose, Transform } from 'class-transformer';
 
 import { ScopeList, ScopeType } from '../types/scope.type';
 
@@ -74,6 +74,11 @@ export class TokenResDto {
     example: 'openid profile email',
     description: 'scope',
     enum: ScopeList,
+  })
+  @Transform(({ value }) => {
+    if (Array.isArray(value)) return value.join(' ');
+    if (typeof value === 'string') return value;
+    return null;
   })
   scope: ScopeType[];
 }

--- a/src/oauth/dto/res.dto.ts
+++ b/src/oauth/dto/res.dto.ts
@@ -75,11 +75,14 @@ export class TokenResDto {
     description: 'scope',
     enum: ScopeList,
   })
-  @Transform(({ value }) => {
-    if (Array.isArray(value)) return value.join(' ');
-    if (typeof value === 'string') return value;
-    return null;
-  })
+  @Transform(
+    ({ value }) => {
+      if (Array.isArray(value)) return value.join(' ');
+      if (typeof value === 'string') return value;
+      return null;
+    },
+    { toPlainOnly: true },
+  )
   scope: ScopeType[];
 }
 


### PR DESCRIPTION
```ts
  const accessToken = 'accessToken';
  const refreshToken = 'refreshToken';
  const idToken = 'idToken';
  const scope = ['scope'];
  const cache = {
    scope,
  };
  const res = {
    accessToken,
    tokenType: 'Bearer',
    expiresIn: 3 * 60 * 60, // 3 hours
    refreshToken,
    refreshTokenExpiresIn: 3 * 30 * 24 * 60 * 60, // 3 months
    idToken,
    scope: cache.scope,
  };
  console.log(plainToInstance(TokenResDto, res));
  console.log(instanceToPlain(plainToInstance(TokenResDto, res)));
```

```
TokenResDto {
  accessToken: 'accessToken',
  tokenType: 'Bearer',
  expiresIn: 10800,
  refreshToken: 'refreshToken',
  refreshTokenExpiresIn: 7776000,
  idToken: 'idToken',
  scope: [ 'scope', 'scope2' ]
}
{
  access_token: 'accessToken',
  token_type: 'Bearer',
  expires_in: 10800,
  refresh_token: 'refreshToken',
  refresh_token_expires_in: 7776000,
  id_token: 'idToken',
  scope: 'scope scope2'
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 토큰 응답의 scope 값이 항상 일관된 문자열 형식으로 표시되도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->