### PR TITLE
docs: add http respones in swagger

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -15,13 +15,14 @@ import {
 import {
   ApiCreatedResponse,
   ApiInternalServerErrorResponse,
+  ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
-import { PublicKeyCredentialRequestOptionsJSON } from '@simplewebauthn/types';
 import { FastifyReply, FastifyRequest } from 'fastify';
+import { PasskeyOptionResDto } from 'src/user/dto/res.dto';
 
 import { AuthService } from './auth.service';
 import {
@@ -142,10 +143,16 @@ export class AuthController {
     summary: 'get the passkey options',
     description: '패스키 로그인을 위한 정보를 불러옵니다.',
   })
+  @ApiOkResponse({
+    description: 'success',
+    type: PasskeyOptionResDto,
+  })
+  @ApiNotFoundResponse({ description: 'Email is not found' })
+  @ApiInternalServerErrorResponse({ description: 'server error' })
   @Post('passkey')
   async authenticateOptions(
     @Body() { email }: PasskeyDto,
-  ): Promise<PublicKeyCredentialRequestOptionsJSON> {
+  ): Promise<PasskeyOptionResDto> {
     return this.authService.authenticateOptions(email);
   }
 
@@ -153,6 +160,10 @@ export class AuthController {
     summary: 'verify the passkey options',
     description: '패스키를 인증합니다.',
   })
+  @ApiCreatedResponse({ description: 'success', type: LoginResDto })
+  @ApiUnauthorizedResponse({ description: 'Response is invalid' })
+  @ApiNotFoundResponse({ description: 'Email is not found' })
+  @ApiInternalServerErrorResponse({ description: 'server error' })
   @Post('passkey/verify')
   async verifyAuthentication(
     @Body() { email, authenticationResponse }: VerifyPasskeyAuthenticationDto,

--- a/src/user/dto/res.dto.ts
+++ b/src/user/dto/res.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { User } from '@prisma/client';
+import { AuthenticatorTransportFuture } from '@simplewebauthn/types';
 import { Exclude } from 'class-transformer';
 
 import { UserConsentType } from '../types/userConsent.type';
@@ -153,4 +154,73 @@ export class UserConsentListResDto {
     type: [UserConsentResDto],
   })
   list: UserConsentResDto[];
+}
+
+class AllowCredentialDto {
+  @ApiProperty({
+    description: 'CredentialID of passkey (Base64URL)',
+    example: 'aUF_gprsh...',
+  })
+  id: string;
+
+  @ApiProperty({ description: 'Credential type', example: 'public-key' })
+  type: 'public-key';
+
+  @ApiPropertyOptional({
+    description: 'List of communication method',
+    example: ['internal'],
+  })
+  transports?: AuthenticatorTransportFuture[];
+}
+
+class AuthenticationExtensionsDto {
+  @ApiPropertyOptional({ description: 'appid extension' })
+  appid?: string;
+
+  @ApiPropertyOptional({ description: 'credProps extension' })
+  credProps?: boolean;
+
+  @ApiPropertyOptional({ description: 'hmacCreateSecret extension' })
+  hmacCreateSecret?: boolean;
+
+  @ApiPropertyOptional({ description: 'minPinLength extension' })
+  minPinLength?: boolean;
+}
+
+export class PasskeyOptionResDto {
+  @ApiProperty({
+    description: 'challenge (Base64URL)',
+    example: 'HPv7vydo...',
+  })
+  challenge: string;
+
+  @ApiPropertyOptional({ description: 'request timeout(ms)', example: 60000 })
+  timeout?: number;
+
+  @ApiPropertyOptional({
+    description: 'Relying Party ID',
+    example: 'idp.gistory.me',
+  })
+  rpId?: string;
+
+  @ApiPropertyOptional({
+    example: [AllowCredentialDto],
+    description: 'Passkey list',
+    type: [AllowCredentialDto],
+  })
+  allowCredentials?: AllowCredentialDto[];
+
+  @ApiPropertyOptional({
+    description: 'User verification policy',
+    example: 'preferred',
+    enum: ['required', 'discouraged', 'preferred'],
+  })
+  userVerification?: 'required' | 'discouraged' | 'preferred';
+
+  @ApiPropertyOptional({
+    example: [AuthenticationExtensionsDto],
+    description: 'WebAuthn extensions',
+    type: [AuthenticationExtensionsDto],
+  })
+  extensions?: AuthenticationExtensionsDto;
 }

--- a/src/user/dto/res.dto.ts
+++ b/src/user/dto/res.dto.ts
@@ -218,9 +218,9 @@ export class PasskeyOptionResDto {
   userVerification?: 'required' | 'discouraged' | 'preferred';
 
   @ApiPropertyOptional({
-    example: [AuthenticationExtensionsDto],
+    example: AuthenticationExtensionsDto,
     description: 'WebAuthn extensions',
-    type: [AuthenticationExtensionsDto],
+    type: AuthenticationExtensionsDto,
   })
   extensions?: AuthenticationExtensionsDto;
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -22,13 +22,13 @@ import {
   ApiCreatedResponse,
   ApiForbiddenResponse,
   ApiInternalServerErrorResponse,
+  ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 import { User } from '@prisma/client';
-import { PublicKeyCredentialRequestOptionsJSON } from '@simplewebauthn/types';
 import { GetUser } from 'src/auth/decorator/getUser.decorator';
 import { UserGuard } from 'src/auth/guard/auth.guard';
 
@@ -40,6 +40,7 @@ import {
   VerifyPasskeyRegistrationDto,
 } from './dto/req.dto';
 import {
+  PasskeyOptionResDto,
   UpdateUserPictureResDto,
   UserConsentListResDto,
   UserConsentResDto,
@@ -190,10 +191,16 @@ export class UserController {
     summary: 'register the passkey',
     description: '패스키를 등록을 위한 challenge를 발급합니다.',
   })
+  @ApiOkResponse({
+    description: 'success',
+    type: PasskeyOptionResDto,
+  })
+  @ApiNotFoundResponse({ description: 'Email is not found' })
+  @ApiInternalServerErrorResponse({ description: 'server error' })
   @Post('passkey')
   async registerOptions(
     @Body() { email }: IssueUserSecretDto,
-  ): Promise<PublicKeyCredentialRequestOptionsJSON> {
+  ): Promise<PasskeyOptionResDto> {
     return await this.userService.registerOptions(email);
   }
 
@@ -201,6 +208,10 @@ export class UserController {
     summary: 'verify the registration options',
     description: '패스키 등록합니다.',
   })
+  @ApiOkResponse({ description: 'success', type: Boolean })
+  @ApiUnauthorizedResponse({ description: 'Response is invalid' })
+  @ApiNotFoundResponse({ description: 'Email is not found' })
+  @ApiInternalServerErrorResponse({ description: 'server error' })
   @Post('passkey/verify')
   async verifyRegistration(
     @Body() { email, registrationResponse }: VerifyPasskeyRegistrationDto,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 패스키 등록/인증 옵션 응답에 challenge, timeout, rpId, allowCredentials, userVerification, extensions 등 추가 속성 및 신규 응답 DTO(PasskeyOptionResDto) 도입.
- 문서화
  - Swagger 문서 강화: 관련 엔드포인트에 성공/오류 응답(200/201, 401, 404, 500) 스키마 및 설명 추가.
- 리팩터링
  - 인증/등록 옵션 응답 타입을 통합해 API 응답 형식 일관성 향상.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->