### PR TITLE
Revert "fix: alter original passkey name to unnamed"

### DIFF
--- a/prisma/migrations/20250914103918_add_name_in_authenticator/migration.sql
+++ b/prisma/migrations/20250914103918_add_name_in_authenticator/migration.sql
@@ -4,8 +4,5 @@
   - Added the required column `name` to the `authenticator` table without a default value. This is not possible if the table is not empty.
 
 */
--- DropIndex
-DROP INDEX "authenticator_credential_id_key";
-
 -- AlterTable
 ALTER TABLE "authenticator" ADD COLUMN     "name" TEXT NOT NULL;

--- a/prisma/migrations/20250914103918_add_name_in_authenticator/migration.sql
+++ b/prisma/migrations/20250914103918_add_name_in_authenticator/migration.sql
@@ -8,6 +8,4 @@
 DROP INDEX "authenticator_credential_id_key";
 
 -- AlterTable
-ALTER TABLE "authenticator" ADD COLUMN     "name" TEXT;
-UPDATE "authenticator" SET "name" = 'Unnamed' WHERE "name" IS NULL;
-ALTER TABLE "authenticator" ALTER COLUMN "name" SET NOT NULL;
+ALTER TABLE "authenticator" ADD COLUMN     "name" TEXT NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -89,7 +89,7 @@ model Consent {
 model Authenticator {
   id            String  @id @default(uuid())
   name          String
-  credentialId  String  @map("credential_id")
+  credentialId  String  @unique @map("credential_id")
   publicKey     Bytes   @map("public_key")
   counter       Int
   userUuid      String  @db.Uuid @map("user_uuid")

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -236,6 +236,7 @@ export class UserController {
   @ApiOkResponse({ description: 'success', type: Boolean })
   @ApiUnauthorizedResponse({ description: 'token not valid' })
   @ApiNotFoundResponse({ description: 'Email is not found' })
+  @ApiConflictResponse({ description: 'Credential id conflict' })
   @ApiInternalServerErrorResponse({ description: 'server error' })
   @UseGuards(UserGuard)
   @Post('passkey/verify')

--- a/src/user/user.repository.ts
+++ b/src/user/user.repository.ts
@@ -269,9 +269,24 @@ export class UserRepository {
       userUuid: string;
     },
   ): Promise<Authenticator> {
-    return this.prismaService.authenticator.create({
-      data: { ...authenticator, name },
-    });
+    return this.prismaService.authenticator
+      .create({
+        data: { ...authenticator, name },
+      })
+      .catch((error) => {
+        if (error instanceof PrismaClientKnownRequestError) {
+          if (error.code === 'P2002') {
+            this.logger.debug(
+              `conflict credentialId: ${authenticator.credentialId}`,
+            );
+            throw new ConflictException('conflict credentialId');
+          }
+          this.logger.debug(`prisma error occurred: ${error.code}`);
+          throw new InternalServerErrorException();
+        }
+        this.logger.error(`update user password error: ${error}`);
+        throw new InternalServerErrorException();
+      });
   }
 
   async updatePasskey(id: string, name: string): Promise<BasicPasskeyDto> {


### PR DESCRIPTION
Reverts gsainfoteam/idp-be#154
db 충돌은 해결했는데 credenialId가 이론상 unique 하지 않다고 해서 unique를 제거했더니 얘를 pk로 쓸 수 없어서...
그냥 unique로 하고 우연히 같게 나오면 409 띄우는게 맞는거 같아요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **문서**
  - 등록 검증 API에 충돌(409) 응답이 추가되어 오류 상황이 더 명확히 문서화되었습니다.
- **버그 수정**
  - 인증자 저장 시 중복 키 등 DB 오류를 잡아 적절한 충돌 또는 내부 서버 오류로 매핑하도록 예외 처리를 강화했습니다.
- **작업(Chore)**
  - 인증자 테이블에 이름 필드와 credentialId 고유 제약이 추가되어 데이터 무결성이 강화됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->