### PR TITLE
feat: save createdAt, loginAt in authenticator(passkey) of database

### DIFF
--- a/docs/erd.md
+++ b/docs/erd.md
@@ -3,60 +3,60 @@ erDiagram
 
   "user" {
     String uuid "🗝️"
-    String password 
+    String password
     String profile "❓"
     String picture "❓"
-    String name 
-    String email 
-    String student_id 
-    String phone_number 
-    DateTime createdAt 
-    DateTime updatedAt 
+    String name
+    String email
+    String student_id
+    String phone_number
+    DateTime createdAt
+    DateTime updatedAt
     }
-  
+
 
   "client" {
     String uuid "🗝️"
-    String secret 
-    String name 
+    String secret
+    String name
     String picture "❓"
-    String urls 
-    DateTime createdAt 
-    DateTime updatedAt 
+    String urls
+    DateTime createdAt
+    DateTime updatedAt
     DateTime delete_requested_at "❓"
-    Boolean idTokenAllowed 
-    String scopes 
-    String optional_scopes 
+    Boolean idTokenAllowed
+    String scopes
+    String optional_scopes
     }
-  
+
 
   "refresh_token" {
     String token "🗝️"
-    DateTime createdAt 
-    DateTime expiresAt 
+    DateTime createdAt
+    DateTime expiresAt
     String nonce "❓"
-    String scopes 
+    String scopes
     }
-  
+
 
   "consent" {
-    String scopes 
-    DateTime createdAt 
-    DateTime updatedAt 
+    String scopes
+    DateTime createdAt
+    DateTime updatedAt
     }
-  
+
 
   "authenticator" {
-    String user_uuid "🗝️"
-    String name 
-    String credential_id 
-    Bytes public_key 
-    Int counter 
-    String user_uuid 
-    DateTime created_at 
+    String id "🗝️"
+    String name
+    String credential_id
+    Bytes public_key
+    Int counter
+    String user_uuid
+    DateTime created_at
     DateTime login_at "❓"
     }
-  
+
     "user" o{--}o "client" : "clients"
     "user" o{--}o "consent" : "consent"
     "user" o{--}o "refresh_token" : "RefreshToken"

--- a/docs/erd.md
+++ b/docs/erd.md
@@ -53,6 +53,8 @@ erDiagram
     Bytes public_key 
     Int counter 
     String user_uuid 
+    DateTime created_at 
+    DateTime login_at "❓"
     }
   
     "user" o{--}o "client" : "clients"

--- a/prisma/migrations/20250929093848_add_created_at_authenticator/migration.sql
+++ b/prisma/migrations/20250929093848_add_created_at_authenticator/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "authenticator" ADD COLUMN     "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "login_at" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -93,6 +93,8 @@ model Authenticator {
   publicKey     Bytes   @map("public_key")
   counter       Int
   userUuid      String  @db.Uuid @map("user_uuid")
+  createdAt     DateTime  @default(now()) @map("created_at")
+  loginAt       DateTime? @map("login_at")
 
   user          User    @relation(fields: [userUuid], references: [uuid], onDelete: Cascade)
 

--- a/src/auth/auth.repository.ts
+++ b/src/auth/auth.repository.ts
@@ -95,7 +95,10 @@ export class AuthRepository {
         where: {
           credentialId,
         },
-        data: { counter },
+        data: {
+          counter,
+          loginAt: new Date(),
+        },
       })
       .catch((error) => {
         if (error instanceof PrismaClientKnownRequestError) {

--- a/src/user/dto/res.dto.ts
+++ b/src/user/dto/res.dto.ts
@@ -318,4 +318,18 @@ export class BasicPasskeyDto {
     description: 'Passkey name',
   })
   name: string;
+
+  @ApiProperty({
+    example: '2025-01-01T00:00:00.000Z',
+    description: 'Date the passkey was created',
+  })
+  createdAt: Date;
+
+  @ApiProperty({
+    example: '2025-01-01T00:00:00.000Z',
+    description: 'Date the client was logined',
+    type: 'string',
+    format: 'date-time',
+  })
+  loginAt: Date | null;
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -256,7 +256,7 @@ export class UserController {
     description: '패스키의 이름을 수정합니다.',
   })
   @ApiBearerAuth('user:jwt')
-  @ApiOkResponse({ description: 'success', type: BasicPasskeyDto })
+  @ApiOkResponse({ description: 'success' })
   @ApiUnauthorizedResponse({ description: 'token not valid' })
   @ApiForbiddenResponse({ description: 'Invalid user or token' })
   @ApiNotFoundResponse({ description: 'Id is not found' })
@@ -267,7 +267,7 @@ export class UserController {
     @GetUser() user: User,
     @Param('id', ParseUUIDPipe) id: string,
     @Body() { name }: ChangePasskeyNameDto,
-  ): Promise<BasicPasskeyDto> {
+  ): Promise<void> {
     return await this.userService.updatePasskey(id, name, user.uuid);
   }
 

--- a/src/user/user.repository.ts
+++ b/src/user/user.repository.ts
@@ -238,6 +238,8 @@ export class UserRepository {
       select: {
         id: true,
         name: true,
+        createdAt: true,
+        loginAt: true,
       },
     });
   }
@@ -289,15 +291,11 @@ export class UserRepository {
       });
   }
 
-  async updatePasskey(id: string, name: string): Promise<BasicPasskeyDto> {
-    return await this.prismaService.authenticator
+  async updatePasskey(id: string, name: string): Promise<void> {
+    await this.prismaService.authenticator
       .update({
         where: { id },
         data: { name },
-        select: {
-          id: true,
-          name: true,
-        },
       })
       .catch((error) => {
         if (error instanceof PrismaClientKnownRequestError) {

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -293,7 +293,7 @@ export class UserService {
     id: string,
     name: string,
     userUuid: string,
-  ): Promise<BasicPasskeyDto> {
+  ): Promise<void> {
     const auth = await this.userRepository.getAuthenticator(id);
 
     if (auth.userUuid !== userUuid) throw new ForbiddenException();


### PR DESCRIPTION
패스키 생성 날짜, 마지막 로그인 날짜 저장

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 패스키에 생성일(createdAt)과 마지막 로그인시간(loginAt)이 추가되어 목록과 응답에서 표시됩니다.
  * 로그인 시 loginAt이 자동 갱신됩니다.

* 리팩터
  * 패스키 이름 변경 API는 더 이상 패스키 정보를 응답 본문으로 반환하지 않고 빈 응답을 제공합니다.

* 문서
  * ERD에 authenticator의 created_at 및 login_at 필드가 반영되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->