### PR TITLE
159 kdh non email passkey

### DIFF
--- a/docs/erd.md
+++ b/docs/erd.md
@@ -49,7 +49,6 @@ erDiagram
   "authenticator" {
     String id "🗝️"
     String name
-    String credential_id
     Bytes public_key
     Int counter
     String user_uuid

--- a/prisma/migrations/20251002070932_change_crdential_id_to_id/migration.sql
+++ b/prisma/migrations/20251002070932_change_crdential_id_to_id/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `credential_id` on the `authenticator` table. All the data in the column will be lost.
+
+*/
+-- DropIndex
+DROP INDEX "authenticator_credential_id_key";
+
+-- AlterTable
+ALTER TABLE "authenticator" DROP COLUMN "credential_id";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -87,9 +87,8 @@ model Consent {
 }
 
 model Authenticator {
-  id            String  @id @default(uuid())
+  id            String  @id
   name          String
-  credentialId  String  @unique @map("credential_id")
   publicKey     Bytes   @map("public_key")
   counter       Int
   userUuid      String  @db.Uuid @map("user_uuid")

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -24,11 +24,7 @@ import {
 import { FastifyReply, FastifyRequest } from 'fastify';
 
 import { AuthService } from './auth.service';
-import {
-  LoginDto,
-  PasskeyDto,
-  VerifyPasskeyAuthenticationDto,
-} from './dto/req.dto';
+import { LoginDto, VerifyPasskeyAuthenticationDto } from './dto/req.dto';
 import { LoginResDto, PasskeyAuthOptionResDto } from './dto/res.dto';
 
 @ApiTags('auth')
@@ -149,10 +145,8 @@ export class AuthController {
   @ApiNotFoundResponse({ description: 'Email is not found' })
   @ApiInternalServerErrorResponse({ description: 'server error' })
   @Post('passkey')
-  async authenticateOptions(
-    @Body() { email }: PasskeyDto,
-  ): Promise<PasskeyAuthOptionResDto> {
-    return this.authService.authenticateOptions(email);
+  async authenticateOptions(): Promise<PasskeyAuthOptionResDto> {
+    return this.authService.authenticateOptions();
   }
 
   @ApiOperation({

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -165,7 +165,7 @@ export class AuthController {
   @ApiInternalServerErrorResponse({ description: 'server error' })
   @Post('passkey/verify')
   async verifyAuthentication(
-    @Body() { email, authenticationResponse }: VerifyPasskeyAuthenticationDto,
+    @Body() { key, authenticationResponse }: VerifyPasskeyAuthenticationDto,
     @Res({ passthrough: true }) response: FastifyReply,
   ): Promise<LoginResDto> {
     const {
@@ -174,7 +174,7 @@ export class AuthController {
       refreshTokenExpireTime,
       accessTokenExpireTime,
     } = await this.authService.verifyAuthentication(
-      email,
+      key,
       authenticationResponse,
     );
     response.cookie('accessToken', accessToken, {

--- a/src/auth/auth.repository.ts
+++ b/src/auth/auth.repository.ts
@@ -65,11 +65,11 @@ export class AuthRepository {
       });
   }
 
-  async findAuthenticator(credentialId: string): Promise<Authenticator> {
+  async findAuthenticator(id: string): Promise<Authenticator> {
     return this.prismaService.authenticator
       .findUniqueOrThrow({
         where: {
-          credentialId,
+          id,
         },
       })
       .catch((error) => {
@@ -87,13 +87,13 @@ export class AuthRepository {
   }
 
   async updatePasskeyCounter(
-    credentialId: string,
+    id: string,
     counter: number,
   ): Promise<Authenticator> {
     return this.prismaService.authenticator
       .update({
         where: {
-          credentialId,
+          id,
         },
         data: {
           counter,

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -137,7 +137,6 @@ export class AuthService {
         expectedRPID: this.passkeyRpId,
         credential: {
           ...authenticator,
-          id: authenticator.credentialId,
         },
         requireUserVerification: true,
       },
@@ -148,7 +147,7 @@ export class AuthService {
     }
 
     await this.authRepository.updatePasskeyCounter(
-      authenticator.credentialId,
+      authenticator.id,
       authenticationInfo.newCounter,
     );
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,11 +1,6 @@
 import { Loggable } from '@lib/logger/decorator/loggable';
 import { RedisService } from '@lib/redis';
-import {
-  Injectable,
-  Logger,
-  NotFoundException,
-  UnauthorizedException,
-} from '@nestjs/common';
+import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import { User } from '@prisma/client';
@@ -13,16 +8,14 @@ import {
   generateAuthenticationOptions,
   verifyAuthenticationResponse,
 } from '@simplewebauthn/server';
-import {
-  AuthenticationResponseJSON,
-  PublicKeyCredentialRequestOptionsJSON,
-} from '@simplewebauthn/types';
+import { AuthenticationResponseJSON } from '@simplewebauthn/types';
 import * as bcrypt from 'bcryptjs';
 import * as crypto from 'crypto';
 import ms, { StringValue } from 'ms';
 
 import { AuthRepository } from './auth.repository';
 import { LoginDto } from './dto/req.dto';
+import { PasskeyAuthOptionResDto } from './dto/res.dto';
 import { LoginResultType } from './types/loginResult.type';
 
 @Injectable()
@@ -107,47 +100,30 @@ export class AuthService {
     return this.authRepository.findUserByUuid(uuid);
   }
 
-  async authenticateOptions(
-    email: string,
-  ): Promise<PublicKeyCredentialRequestOptionsJSON> {
-    const user = await this.authRepository.findUserByEmail(email);
-
-    if (!user || user.authenticators.length === 0) {
-      throw new NotFoundException();
-    }
-
+  async authenticateOptions(): Promise<PasskeyAuthOptionResDto> {
     const options = await generateAuthenticationOptions({
       rpID: this.passkeyRpId,
-      allowCredentials: user.authenticators.map((auth) => ({
-        id: auth.credentialId,
-        type: 'public-key',
-      })),
     });
+    const key = crypto.randomUUID();
 
-    await this.redisService.set<string>(user.uuid, options.challenge, {
+    await this.redisService.set<string>(key, options.challenge, {
       prefix: this.passkeyPrefix,
       ttl: 10 * 60,
     });
 
-    return options;
+    return { key, ...options };
   }
 
   async verifyAuthentication(
-    email: string,
+    key: string,
     response: AuthenticationResponseJSON,
   ): Promise<LoginResultType> {
-    const user = await this.authRepository.findUserByEmail(email);
-    if (!user) throw new NotFoundException();
-
-    const expectedChallenge = await this.redisService.getOrThrow<string>(
-      user.uuid,
-      {
-        prefix: this.passkeyPrefix,
-      },
-    );
+    const expectedChallenge = await this.redisService.getOrThrow<string>(key, {
+      prefix: this.passkeyPrefix,
+    });
     if (!expectedChallenge) throw new UnauthorizedException();
 
-    await this.redisService.del(user.uuid, { prefix: this.passkeyPrefix });
+    await this.redisService.del(key, { prefix: this.passkeyPrefix });
 
     const authenticator = await this.authRepository.findAuthenticator(
       response.id,
@@ -176,7 +152,7 @@ export class AuthService {
       authenticationInfo.newCounter,
     );
 
-    return this.issueTokens(user.uuid);
+    return this.issueTokens(authenticator.userUuid);
   }
 
   /**

--- a/src/auth/dto/req.dto.ts
+++ b/src/auth/dto/req.dto.ts
@@ -125,18 +125,11 @@ class AuthenticationResponseDto {
 
 export class VerifyPasskeyAuthenticationDto {
   @ApiProperty({
-    example: 'JohbDoe@gm.gist.ac.kr',
-    description: '유저의 이메일 주소',
+    example: 'uuid',
+    description: 'uuid for challenge',
   })
-  @IsEmail()
-  @IsGistEmail()
-  @Transform(({ value }) => {
-    if (typeof value === 'string') {
-      return value.toLowerCase();
-    }
-    throw new BadRequestException('이메일 형식이 올바르지 않습니다.');
-  })
-  email: string;
+  @IsString()
+  key: string;
 
   @ApiProperty({
     description: '유저의 패스키 인증 응답',

--- a/src/auth/dto/req.dto.ts
+++ b/src/auth/dto/req.dto.ts
@@ -35,22 +35,6 @@ export class LoginDto {
   password: string;
 }
 
-export class PasskeyDto {
-  @ApiProperty({
-    example: 'JohbDoe@gm.gist.ac.kr',
-    description: '유저의 이메일 주소',
-  })
-  @IsEmail()
-  @IsGistEmail()
-  @Transform(({ value }) => {
-    if (typeof value === 'string') {
-      return value.toLowerCase();
-    }
-    throw new BadRequestException('이메일 형식이 올바르지 않습니다.');
-  })
-  email: string;
-}
-
 class AuthenticationResponseObjectDto {
   @ApiProperty({ example: 'eyJ0eXBlIjoid2ViYXV0aG...' })
   @IsString()

--- a/src/auth/dto/res.dto.ts
+++ b/src/auth/dto/res.dto.ts
@@ -49,6 +49,12 @@ class AuthenticationExtensionsDto {
 
 export class PasskeyAuthOptionResDto {
   @ApiProperty({
+    description: 'uuid for challenge',
+    example: 'uuid',
+  })
+  key: string;
+
+  @ApiProperty({
     description: 'challenge (Base64URL)',
     example: 'HPv7vydo...',
   })

--- a/src/user/user.repository.ts
+++ b/src/user/user.repository.ts
@@ -265,7 +265,7 @@ export class UserRepository {
   async saveAuthenticator(
     name: string,
     authenticator: {
-      credentialId: string;
+      id: string;
       publicKey: Uint8Array;
       counter: number;
       userUuid: string;
@@ -278,9 +278,7 @@ export class UserRepository {
       .catch((error) => {
         if (error instanceof PrismaClientKnownRequestError) {
           if (error.code === 'P2002') {
-            this.logger.debug(
-              `conflict credentialId: ${authenticator.credentialId}`,
-            );
+            this.logger.debug(`conflict credentialId: ${authenticator.id}`);
             throw new ConflictException('conflict credentialId');
           }
           this.logger.debug(`prisma error occurred: ${error.code}`);

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -238,7 +238,7 @@ export class UserService {
       userID: Buffer.from(user.uuid),
       userName: user.name,
       excludeCredentials: user.authenticators.map((auth) => ({
-        id: auth.credentialId,
+        id: auth.id,
         type: 'public-key',
       })),
     });
@@ -280,7 +280,7 @@ export class UserService {
     const { id, publicKey, counter } = registrationInfo.credential;
 
     await this.userRepository.saveAuthenticator(name, {
-      credentialId: id,
+      id,
       publicKey,
       counter,
       userUuid: user.uuid,


### PR DESCRIPTION
이메일 없이 idp 로그인 가능하게 만들기

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 패스키 인증 옵션 응답에 챌린지 식별용 key가 포함됩니다(유효기간 10분).

- 리팩터
  - 인증 옵션 요청에 이메일이 더 이상 필요 없으며, 검증 단계에서 email 대신 key를 사용합니다.
  - 요청/응답 스키마 변경: VerifyPasskeyAuthenticationDto에 key 추가, email 제거; PasskeyDto 삭제.
  - 오류 응답 단순화(Unauthorized 중심).

- 기타
  - 인증자 식별자 관련 데이터 모델 및 DB 마이그레이션(credential_id 제거, 필드명 변경).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->