### PR TITLE
fix: use base64url for user image key

### DIFF
--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -214,7 +214,7 @@ export class UserService {
     length: number,
     userUuid: string,
   ): Promise<UpdateUserPictureResDto> {
-    const key = `user/${userUuid}/profile_${crypto.randomBytes(16).toString('base64')}.webp`;
+    const key = `user/${userUuid}/profile_${crypto.randomBytes(16).toString('base64url')}.webp`;
     const presignedUrl = await this.objectService.createPresignedUrl(
       key,
       length,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 프로필 사진 저장 시 파일명 인코딩 방식을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->