### PR TITLE
fix: update verification types and lists for email and phone number

### DIFF
--- a/src/verify/dto/req.dto.ts
+++ b/src/verify/dto/req.dto.ts
@@ -4,7 +4,10 @@ import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
 import { IsEmail, IsString } from 'class-validator';
 
-import { VerificationList, VerificationType } from '../types/verification.type';
+import {
+  VerificationCodeList,
+  VerificationCodeType,
+} from '../types/verification.type';
 
 export class SendEmailCodeDto {
   @ApiProperty({
@@ -44,10 +47,10 @@ export class VerifyCodeDto {
     example: 'email or phoneNumber',
     description: '인증 타입 (email 또는 phoneNumber)',
     required: true,
-    enum: VerificationList,
+    enum: VerificationCodeList,
   })
   @IsString()
-  hint: VerificationType;
+  hint: VerificationCodeType;
 }
 
 export class VerifyStudentIdDto {

--- a/src/verify/types/verification.type.ts
+++ b/src/verify/types/verification.type.ts
@@ -1,2 +1,5 @@
-export const VerificationList = ['email'];
+export const VerificationList = ['email', 'phoneNumber', 'studentId'] as const;
 export type VerificationType = (typeof VerificationList)[number];
+
+export const VerificationCodeList = ['email', 'phoneNumber'] as const;
+export type VerificationCodeType = (typeof VerificationCodeList)[number];


### PR DESCRIPTION
POST /verify API에서 hint 필드가 `'email'` 타입으로만 고정되어 있습니다.
hint 필드 타입 정의를 수정하여, `'email' | 'phoneNumber'`를 사용할 수 있게 했습니다.
또한, 기존에 `as const`를 사용하지 않아 `hint` 타입이 `string`으로만 나타나있어 이 또한 수정했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 휴대폰 번호 및 학번 인증 방식 추가 지원

* **개선 사항**
  * 인증 코드 처리 관련 타입 정의 최적화 및 안정성 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->