### PR TITLE
feat: include verified info when requesting oauth userinfo

### DIFF
--- a/src/oauth/dto/res.dto.ts
+++ b/src/oauth/dto/res.dto.ts
@@ -134,6 +134,18 @@ export class UserInfoResDto {
   studentId?: string;
 
   @ApiPropertyOptional({
+    example: true,
+    description: 'is student id verified',
+    required: false,
+    name: 'is_student_id_verified',
+  })
+  @Expose({
+    name: 'is_student_id_verified',
+    toPlainOnly: true,
+  })
+  isStudentIdVerified?: boolean;
+
+  @ApiPropertyOptional({
     example: '01012345678',
     description: 'phone number',
     required: false,
@@ -144,4 +156,16 @@ export class UserInfoResDto {
     toPlainOnly: true,
   })
   phoneNumber?: string;
+
+  @ApiPropertyOptional({
+    example: true,
+    description: 'is phone number verified',
+    required: false,
+    name: 'is_phone_number_verified',
+  })
+  @Expose({
+    name: 'is_phone_number_verified',
+    toPlainOnly: true,
+  })
+  isPhoneNumberVerified?: boolean;
 }

--- a/src/oauth/oauth.service.ts
+++ b/src/oauth/oauth.service.ts
@@ -497,8 +497,14 @@ export class OauthService {
       studentId: tokenData.scope.includes('student_id')
         ? user.studentId
         : undefined,
+      isStudentIdVerified: tokenData.scope.includes('student_id')
+        ? user.isIdVerified
+        : undefined,
       phoneNumber: tokenData.scope.includes('phone_number')
         ? user.phoneNumber
+        : undefined,
+      isPhoneNumberVerified: tokenData.scope.includes('phone_number')
+        ? user.isPhoneNumberVerified
         : undefined,
     };
   }


### PR DESCRIPTION
oauth로 uesrinfo를 요청할 때 학번, 전화번호 인증 여부를 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자 정보 응답에 학생증 인증 여부와 전화번호 인증 여부를 확인할 수 있는 새로운 필드가 추가되었습니다. 해당 권한이 요청될 때만 포함됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->