### PR TITLE
fix: handle empty scope string in ConsentReqDto transform

### DIFF
--- a/src/oauth/dto/req.dto.ts
+++ b/src/oauth/dto/req.dto.ts
@@ -25,7 +25,7 @@ export class ConsentReqDto {
   })
   @Transform(({ value }) => {
     if (typeof value === 'string')
-      return value.split(' ').map((v) => {
+      return value.split(' ').filter((v) => v !== '').map((v) => {
         if (ClientScopeList.includes(v)) return v;
         throw new OauthAuthorizeException('invalid_scope');
       });


### PR DESCRIPTION
- Closes #222 
- `src/oauth/dto/req.dto.ts`: ConsentReqDto scope transform에서 빈 문자열 필터링 (빈 scope 동의 시 invalid_scope 발생 수정)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * OAuth 인증 요청의 scope 입력 파싱 로직을 개선하여, 공백 기반 분할 시 생성되는 빈 문자열이 유효성 검사에서 제외되도록 수정했습니다. 이를 통해 불필요한 검증 오류가 발생하지 않도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->